### PR TITLE
Parse SSH options escape quotes

### DIFF
--- a/lib/method/PACMethod_ssh.pm
+++ b/lib/method/PACMethod_ssh.pm
@@ -236,7 +236,7 @@ sub _parseCfgToOptions
 	@{ $hash{remotePort} }			= ();
 	@{ $hash{advancedOption} }		= ();
 	
-	my @opts = split( /\s+-/, $cmd_line );
+	my @opts = split( /\s+-(?=([^\"]*\"[^\"]*\")*[^\"]*$)/, $cmd_line );
 	foreach my $opt ( @opts )
 	{
 		next unless $opt ne '';


### PR DESCRIPTION
Regexp to allow parsing options outside quotes. As an example, in '-o "ProxyCommand=ssh -W %h:%n ...."', everything between double quotes should be parsed as a single value in ssh options; current implementation splits on -W as well, which should left intact.
